### PR TITLE
chore: release 0.1.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ If **any** of the above is "yes", the bullet spells out the mitigation a running
 
 ---
 
+## [0.1.3] — 2026-04-23
+
+### Changed
+- CI now runs tests on the `dev` branch in addition to `main`.
+
+### Internal
+- Wired PyPI trusted publisher (OIDC) — future `v*` tag pushes auto-publish without an API token.
+
+**Wire-compat:** No envelope, topic, QoS, or MCP tool changes. Safe to upgrade in place.
+
+---
+
 ## [Unreleased] — 2026-04-14
 
 First-day-in-production iteration. Sparrow + Wren deployed on an RPi, broker reachable over loopback for now, Tailscale cross-host documented but not yet exercised in anger.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "swarmbus-py"
-version = "0.1.2"
+version = "0.1.3"
 description = "Reactive pub/sub messaging for AI agents via MQTT"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/swarmbus/__init__.py
+++ b/src/swarmbus/__init__.py
@@ -1,5 +1,5 @@
 # src/swarmbus/__init__.py
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .bus import AgentBus
 from .message import AgentMessage

--- a/src/swarmbus/__init__.py
+++ b/src/swarmbus/__init__.py
@@ -1,5 +1,10 @@
 # src/swarmbus/__init__.py
-__version__ = "0.1.3"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("swarmbus-py")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 from .bus import AgentBus
 from .message import AgentMessage


### PR DESCRIPTION
## Changes

- ci: run tests on dev branch too (3d4cc94)
- chore: bump version to 0.1.3

## Release checklist

- [ ] Merge this PR
- [ ] On main: `git tag v0.1.3 && git push --tags` to trigger PyPI publish via CI
- [ ] Confirm GitHub Actions → Publish to PyPI succeeds
- [ ] Verify on pypi.org/project/swarmbus-py/

> Note: the PR merge itself does NOT trigger PyPI. The tag push does.